### PR TITLE
キーボードショートカットの説明文に対するすし

### DIFF
--- a/like2sushi.css
+++ b/like2sushi.css
@@ -102,3 +102,25 @@ https://github.com/syaro/like2sushi-for-chrome-extension
     height: 16px !important;
     padding: 0px !important;
 }
+
+/* Keyboard shortcut Sushi action */
+#keyboard-shortcut-menu table:first-of-type tr:nth-of-type(2) td:nth-of-type(2){
+    visibility: hidden;
+    position: relative;
+}
+#keyboard-shortcut-menu table:first-of-type tr:nth-of-type(2) td:nth-of-type(2):after{
+    visibility: visible;
+    content: "すし";
+    position: absolute;
+    left: 8px;
+}
+#keyboard-shortcut-menu table:last-of-type tr:nth-of-type(5) td:nth-of-type(2){
+    visibility: hidden;
+    position: relative;
+}
+#keyboard-shortcut-menu table:last-of-type tr:nth-of-type(5) td:nth-of-type(2):after{
+    visibility: visible;
+    content: "すし";
+    position: absolute;
+    left: 8px;
+}


### PR DESCRIPTION
下図の部分の表示を「いいね」⇒「すし」にしましたご確認ください。

![default](https://cloud.githubusercontent.com/assets/9548212/10969920/954270a2-840e-11e5-8bb1-d054d583e4be.png)

すしおいしい…
