### PR TITLE
お寿司ツールチップの表示バグ修正

### DIFF
--- a/like2sushi.css
+++ b/like2sushi.css
@@ -21,13 +21,13 @@ https://github.com/syaro/like2sushi-for-chrome-extension
 }
 
 /* "いいね" - "すし" substitution */
-[data-original-title="いいね"] .HeartAnimation:before {
+[data-original-title="いいね"] .HeartAnimation:before, [data-original-title="お気に入りに登録"] .HeartAnimation:before {
     content: "すし";
     width: 40px;
     left: -6px;
 }
 
-[data-original-title="「いいね」を取り消す"] .HeartAnimation:before {
+[data-original-title="「いいね」を取り消す"] .HeartAnimation:before, [data-original-title="お気に入り削除"] .HeartAnimation:before {
     content: "「すし」を取り消す";
     width: 140px;
     left: -55px;


### PR DESCRIPTION
ツールチップに寿司が表示されないことがあるバグを修正しましたご確認ください。

これは、ツイートを投稿した直後、F5で更新せずに自分のツイートをふぁぼろうとした時限定で起きるようです。
原因は、この条件の時のみ、data-original-title属性が「いいね」になる前の「お気に入りに登録」になってしまっているという、Twitter社側のバグによるもの。おのれTwitter社…。

![default](https://cloud.githubusercontent.com/assets/9548212/11001387/4aaba11c-84ea-11e5-976d-611cd11bfa18.png)
