### PR TITLE
すしの表示位置の修正

### DIFF
--- a/like2sushi.css
+++ b/like2sushi.css
@@ -160,6 +160,6 @@ https://github.com/syaro/like2sushi-for-chrome-extension
     visibility: visible;
     content: "すし";
     position: absolute;
-    top: 4px;
+    top: 24px;
     left: 0;
 }


### PR DESCRIPTION
ころころと変わる仕様変更の闇

![default](https://cloud.githubusercontent.com/assets/9548212/11760223/dc30c0f2-a0d5-11e5-903d-ffb83ad57573.png)

どうやら旧仕様に戻ったみたいですね。
